### PR TITLE
Replace scrapy.Selector with parsel.Selector for better UX for HTML parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ You can also install extra dependencies
 * `pip install "scrapfly-sdk[seepdup]"` for performance improvement
 * `pip install "scrapfly-sdk[concurrency]"` for concurrency out of the box (asyncio / thread)
 * `pip install "scrapfly-sdk[scrapy]"` for scrapy integration
-* `pip install "scrapfly-sdk[scrapy]"` Everything!
+* `pip install "scrapfly-sdk[all]"` Everything!
+
+For use of built-in HTML parser (via `ScrapeApiResponse.selector` property) additional requirement of either [parsel](https://pypi.org/project/parsel/) or [scrapy](https://pypi.org/project/Scrapy/) is required.
 
 ## Get Your API Key
 

--- a/scrapfly/api_response.py
+++ b/scrapfly/api_response.py
@@ -275,10 +275,10 @@ class ScrapeApiResponse:
     @cached_property
     def selector(self) -> 'Selector':
         try:
-            from scrapy import Selector
+            from parsel import Selector
             return Selector(text=self.content)
         except ImportError as e:
-            logger.error('You must install scrapfly[scrapy] to enable this feature')
+            logger.error('You must install parsel or scrapy package to enable this feature')
             raise e
 
     @property


### PR DESCRIPTION
Since Scrapy is using parsel anyways this patch allows to use ScrapeApiResponse.selector property by installing only parsel or scrapy. This approach skips a lot of heavy scrapy dependancies like twisted etc. for users who just need HTML parsing.