### PR TITLE
fix encoding non-text file content on file sink

### DIFF
--- a/scrapfly/api_response.py
+++ b/scrapfly/api_response.py
@@ -449,8 +449,13 @@ class ScrapeApiResponse(ApiResponse):
 
             if content_format in ['clob', 'blob']:
                 api_result['result']['content'], api_result['result']['format'] = self.large_object_handler(callback_url=api_result['result']['content'], format=content_format)
-            elif content_format == 'binary' and isinstance(api_result['result']['content'], bytes):
-                api_result['result']['content'] = BytesIO(b64decode(api_result['result']['content']))
+            elif content_format == 'binary':
+                base64_payload = api_result['result']['content']
+
+                if isinstance(base64_payload, bytes):
+                    base64_payload = base64_payload.decode('utf-8')
+
+                api_result['result']['content'] = BytesIO(b64decode(base64_payload))
 
         return FrozenDict(api_result)
 

--- a/scrapfly/client.py
+++ b/scrapfly/client.py
@@ -754,10 +754,7 @@ class ScrapflyClient:
             file = open(file_path, 'wb')
 
         if isinstance(file_content, str):
-            try:
-                file_content = BytesIO(base64.b64decode(file_content, validate=True))
-            except (base64.binascii.Error, ValueError):
-                file_content = BytesIO(file_content.encode('utf-8'))
+            file_content = BytesIO(file_content.encode('utf-8'))
         elif isinstance(file_content, bytes):
             file_content = BytesIO(file_content)
 

--- a/scrapfly/client.py
+++ b/scrapfly/client.py
@@ -754,7 +754,10 @@ class ScrapflyClient:
             file = open(file_path, 'wb')
 
         if isinstance(file_content, str):
-            file_content = BytesIO(file_content.encode('utf-8'))
+            try:
+                file_content = BytesIO(base64.b64decode(file_content, validate=True))
+            except (base64.binascii.Error, ValueError):
+                file_content = BytesIO(file_content.encode('utf-8'))
         elif isinstance(file_content, bytes):
             file_content = BytesIO(file_content)
 


### PR DESCRIPTION
Currently, `sink` treats string content as plain text, while the content retrieved is base64, hence the file created is malformed. This ensures both types are handled