### PR TITLE
Fix mutable default and remove debug statement

### DIFF
--- a/scrapfly/extraction_config.py
+++ b/scrapfly/extraction_config.py
@@ -64,7 +64,6 @@ class ExtractionConfig(BaseApiConfig):
         ephemeral_template: Optional[Dict] = None     
     ):
         if template:
-            print("WARNGING")
             warnings.warn(
                 "Deprecation warning: 'template' is deprecated. Use 'extraction_template' instead."
             )

--- a/scrapfly/scrapy/request.py
+++ b/scrapfly/scrapy/request.py
@@ -20,8 +20,11 @@ class ScrapflyScrapyRequest(Request):
     # headers:Dict inherited
     # encoding:Dict inherited
 
-    def __init__(self, scrape_config: ScrapeConfig, meta: Dict = {}, *args, **kwargs):
+    def __init__(self, scrape_config: ScrapeConfig, meta: Optional[Dict] = None, *args, **kwargs): 
         self.scrape_config = scrape_config
+
+        if meta is None:
+            meta = {}
 
         meta['scrapfly_scrape_config'] = self.scrape_config
 


### PR DESCRIPTION
## Changes
- Changed `meta: Dict = {}` to `meta: Optional[Dict] = None` in `ScrapFlyScrapyRequest.__init__`
- Added `if meta is None: meta = {}` to handle the None case
- Removed debug print in extraction_config.py that was left over

## Why
Default mutable arguments in python are evaluated once at function definition, not each time the function is called. So every ScrapFlyScrapyRequest instance that doesnt pass meta explicitly would end up sharing the same dict object.

This can cause weird state leakage issues between requests. Found this while looking thru the code and figured it's worth fixing before it causes problems down the line.