### PR TITLE
cloud-browser

### DIFF
--- a/examples/browser/browser_use_basic.py
+++ b/examples/browser/browser_use_basic.py
@@ -1,0 +1,53 @@
+"""
+Basic Browser Use connection test with Scrapfly Cloud Browser.
+
+Browser Use connects to Cloud Browser via CDP. The first connection may trigger
+a reconnection (this is normal - the Cloud Browser allocates the browser instance
+during the initial WebSocket handshake).
+
+Requires: Python 3.11+, browser-use, scrapfly-sdk
+"""
+import asyncio
+from scrapfly import ScrapflyClient, BrowserConfig
+from browser_use import Browser, BrowserProfile
+
+scrapfly = ScrapflyClient(
+    key='scp-live-d8ac176c2f9d48b993b58675bdf71615',
+    cloud_browser_host='wss://browser.scrapfly.home',
+    verify=False,
+)
+
+config = BrowserConfig(
+    proxy_pool='datacenter',
+    os='linux',
+)
+
+cdp_url = scrapfly.cloud_browser(config)
+print(f"CDP URL: {cdp_url[:80]}...")
+
+
+async def test_connection():
+    browser = Browser(
+        browser_profile=BrowserProfile(
+            cdp_url=cdp_url,
+        )
+    )
+
+    # Start the browser session (may reconnect once during allocation)
+    await browser.start()
+    print("Connected to Cloud Browser")
+
+    # Get a page and navigate
+    page = await browser.get_current_page()
+    await page.goto('https://web-scraping.dev/products')
+
+    title = await page.title()
+    url = page.url
+    print(f"Page title: {title}")
+    print(f"Page URL: {url}")
+
+    await browser.close()
+    print("Browser closed successfully")
+
+
+asyncio.run(test_connection())

--- a/examples/browser/browser_use_cli.sh
+++ b/examples/browser/browser_use_cli.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Browser Use CLI with Scrapfly Cloud Browser
+#
+# The CLI connects to Cloud Browser via CDP and provides interactive
+# browser control from the terminal.
+#
+# Requires: browser-use CLI installed (pip install browser-use)
+
+API_KEY="YOUR_API_KEY"
+BROWSER_WS="wss://browser.scrapfly.io?api_key=${API_KEY}&proxy_pool=datacenter&os=linux"
+
+# Open a page in the cloud browser
+browser-use --cdp-url "$BROWSER_WS" open https://web-scraping.dev/products
+
+# Get page state (title, URL, clickable elements)
+browser-use state
+
+# Click on a product link (by element index from state output)
+browser-use click 5
+
+# Take a screenshot
+browser-use screenshot product.png
+
+# Type into a search field
+browser-use input 3 "web scraping"
+
+# Press Enter
+browser-use keys "Enter"
+
+# Close the session (stops billing)
+browser-use close

--- a/examples/browser/browser_use_connect.py
+++ b/examples/browser/browser_use_connect.py
@@ -1,0 +1,52 @@
+"""
+Connect Browser Use AI agent to Scrapfly Cloud Browser.
+
+Browser Use uses the CDP protocol to control remote browsers.
+Note: The initial connection may trigger a WebSocket reconnection - this is normal
+and handled automatically by browser-use's reconnection logic.
+
+Requirements:
+  - Python 3.11+
+  - pip install browser-use scrapfly-sdk langchain-openai
+  - OPENAI_API_KEY environment variable set
+"""
+import asyncio
+from scrapfly import ScrapflyClient, BrowserConfig
+from langchain_openai import ChatOpenAI
+from browser_use import Agent, Browser, BrowserProfile
+
+scrapfly = ScrapflyClient(
+    key='YOUR_API_KEY',
+)
+
+# Generate the Cloud Browser CDP endpoint
+config = BrowserConfig(
+    proxy_pool='datacenter',
+    os='linux',
+)
+cdp_url = scrapfly.cloud_browser(config)
+
+
+async def run_agent():
+    # Connect to Cloud Browser via CDP
+    browser = Browser(
+        browser_profile=BrowserProfile(
+            cdp_url=cdp_url,
+        )
+    )
+
+    # Create AI agent with natural language task
+    agent = Agent(
+        task=(
+            "Go to https://web-scraping.dev/products and extract all product names and prices. "
+            "Return the data as a JSON list."
+        ),
+        llm=ChatOpenAI(model="gpt-4o"),
+        browser=browser,
+    )
+
+    result = await agent.run()
+    print("Agent result:", result)
+
+
+asyncio.run(run_agent())

--- a/examples/browser/playwright_connect.py
+++ b/examples/browser/playwright_connect.py
@@ -1,0 +1,36 @@
+"""Connect to Scrapfly Cloud Browser using Playwright (Python)"""
+from scrapfly import ScrapflyClient, BrowserConfig
+from playwright.sync_api import sync_playwright
+
+scrapfly = ScrapflyClient(key='__API_KEY__')
+
+# Configure Cloud Browser connection
+browser_config = BrowserConfig(
+    proxy_pool='datacenter',
+    os='linux',
+)
+
+# Get the CDP WebSocket URL
+cdp_url = scrapfly.cloud_browser(browser_config)
+
+def run():
+    with sync_playwright() as p:
+        browser = None
+        try:
+            # Connect to Cloud Browser
+            browser = p.chromium.connect_over_cdp(cdp_url)
+
+            context = browser.contexts[0]
+            page = context.pages[0] if context.pages else context.new_page()
+
+            # Navigate and interact
+            page.goto('https://web-scraping.dev')
+            print('Page title:', page.title())
+
+            # Take a screenshot
+            page.screenshot(path='screenshot.png')
+        finally:
+            if browser:
+                browser.close()
+
+run()

--- a/examples/browser/selenium_connect.py
+++ b/examples/browser/selenium_connect.py
@@ -1,0 +1,48 @@
+"""
+Connect to Scrapfly Cloud Browser for Selenium users.
+
+Selenium does not natively support remote CDP WebSocket connections.
+This example uses the /json/version discovery endpoint + Playwright as the CDP transport.
+
+For direct Playwright usage (recommended), see playwright_connect.py
+"""
+import requests
+from playwright.sync_api import sync_playwright
+
+API_KEY = 'scp-live-d8ac176c2f9d48b993b58675bdf71615'
+
+# Discover WebSocket URL via standard Chrome DevTools HTTP endpoint
+version_info = requests.get(
+    'https://browser.scrapfly.home/json/version',
+    params={
+        'key': API_KEY,
+        'proxy_pool': 'datacenter',
+        'os': 'linux',
+        'country': 'us',
+    },
+    verify=False,
+).json()
+
+ws_url = version_info['webSocketDebuggerUrl']
+print(f"Browser: {version_info['Browser']}")
+print(f"WebSocket URL: {ws_url[:80]}...")
+
+# Connect via Playwright CDP
+with sync_playwright() as p:
+    browser = p.chromium.connect_over_cdp(ws_url)
+    context = browser.contexts[0]
+    page = context.pages[0] if context.pages else context.new_page()
+
+    page.goto('https://web-scraping.dev/products')
+    print(f"Page title: {page.title()}")
+
+    # Extract products (Selenium-style)
+    products = page.locator('.product-thumb').all()
+    for product in products[:3]:
+        title = product.locator('h3').inner_text()
+        print(f"  Product: {title}")
+
+    page.screenshot(path='screenshot.png')
+    print("Screenshot saved")
+
+    browser.close()

--- a/examples/browser/session_resume.py
+++ b/examples/browser/session_resume.py
@@ -1,0 +1,62 @@
+"""Session Resume: reconnect to an existing Cloud Browser session"""
+import time
+from scrapfly import ScrapflyClient, BrowserConfig
+from playwright.sync_api import sync_playwright
+
+scrapfly = ScrapflyClient(key='__API_KEY__')
+
+SESSION_ID = 'my-persistent-session'
+
+# Configure with session + auto_close=False for persistence
+browser_config = BrowserConfig(
+    proxy_pool='datacenter',
+    session=SESSION_ID,
+    auto_close=False,
+)
+
+cdp_url = scrapfly.cloud_browser(browser_config)
+
+
+def first_connection():
+    """First connection: navigate and set cookies"""
+    print('=== First Connection ===')
+    with sync_playwright() as p:
+        browser = p.chromium.connect_over_cdp(cdp_url)
+        context = browser.contexts[0]
+        page = context.new_page()
+        page.goto('https://web-scraping.dev')
+
+        # Set a cookie
+        context.add_cookies([{
+            'name': 'session_token',
+            'value': 'abc123',
+            'domain': 'web-scraping.dev',
+            'path': '/'
+        }])
+
+        print('Cookies set, disconnecting...')
+        browser.close()  # Disconnects CDP - browser stays alive (auto_close=false)
+
+
+def second_connection():
+    """Second connection: cookies are still there"""
+    print('=== Second Connection (Resume) ===')
+    with sync_playwright() as p:
+        browser = p.chromium.connect_over_cdp(cdp_url)
+        context = browser.contexts[0]
+        page = context.pages[0] if context.pages else context.new_page()
+
+        # Cookies are still there!
+        cookies = context.cookies('https://web-scraping.dev')
+        print('Cookies from previous session:', cookies)
+
+        browser.close()  # Disconnects CDP
+
+
+first_connection()
+time.sleep(2)  # Wait a bit, then reconnect
+second_connection()
+
+# Terminate the session when fully done
+scrapfly.cloud_browser_session_stop(SESSION_ID)
+print(f'Session {SESSION_ID} terminated')

--- a/examples/browser/stagehand_connect.py
+++ b/examples/browser/stagehand_connect.py
@@ -1,0 +1,45 @@
+"""
+Stagehand Cloud Browser Connection
+
+Stagehand is a JavaScript/TypeScript-only library (@browserbase/stagehand)
+and cannot be used directly from Python.
+
+You can generate the CDP WebSocket URL from Python and use it in your
+JavaScript Stagehand code:
+
+    from scrapfly import ScrapflyClient, BrowserConfig
+
+    scrapfly = ScrapflyClient(key='__API_KEY__')
+    cdp_url = scrapfly.cloud_browser(BrowserConfig(proxy_pool='datacenter'))
+    print(f"Use this CDP URL in your Stagehand JS code: {cdp_url}")
+
+JavaScript Stagehand example:
+
+    import { Stagehand } from "@browserbase/stagehand";
+
+    const stagehand = new Stagehand({
+        env: "BROWSERBASE",
+        browserbaseConnectURL: "wss://browser.scrapfly.io?api_key=YOUR_KEY&proxy_pool=datacenter",
+    });
+
+    await stagehand.init();
+    await stagehand.page.goto("https://web-scraping.dev");
+    await stagehand.act("click on the products link");
+
+    const products = await stagehand.extract({
+        instruction: "extract all product names and prices",
+        schema: { products: [{ name: "string", price: "string" }] }
+    });
+
+    console.log("Products:", products);
+    await stagehand.close();
+
+For full documentation, see:
+https://scrapfly.io/docs/cloud-browser-api/stagehand
+"""
+
+from scrapfly import ScrapflyClient, BrowserConfig
+
+scrapfly = ScrapflyClient(key='__API_KEY__')
+cdp_url = scrapfly.cloud_browser(BrowserConfig(proxy_pool='datacenter', os='linux'))
+print(f"Use this CDP URL in your Stagehand JS code:\n{cdp_url}")

--- a/scrapfly/__init__.py
+++ b/scrapfly/__init__.py
@@ -48,6 +48,7 @@ from .crawler import (
     CrawlerWebhook,
     webhook_from_payload
 )
+from .browser_config import BrowserConfig, ProxyPool, OperatingSystem
 
 
 __all__: Tuple[str, ...] = (
@@ -102,4 +103,7 @@ __all__: Tuple[str, ...] = (
     'CrawlCompletedWebhook',
     'CrawlerWebhook',
     'webhook_from_payload',
+    'BrowserConfig',
+    'ProxyPool',
+    'OperatingSystem',
 )

--- a/scrapfly/browser_config.py
+++ b/scrapfly/browser_config.py
@@ -1,0 +1,211 @@
+from enum import Enum
+from typing import Optional, Union, Dict, List
+from urllib.parse import urlencode
+
+from .api_config import BaseApiConfig
+
+
+class ProxyPool(Enum):
+    DATACENTER = "datacenter"
+    RESIDENTIAL = "residential"
+
+
+class OperatingSystem(Enum):
+    LINUX = "linux"
+    WINDOWS = "windows"
+    MACOS = "macos"
+
+
+class BrowserConfig(BaseApiConfig):
+
+    CLOUD_BROWSER_HOST = 'wss://browser.scrapfly.io'
+
+    def __init__(
+        self,
+        proxy_pool: Optional[Union[str, ProxyPool]] = None,
+        os: Optional[Union[str, OperatingSystem]] = None,
+        session: Optional[str] = None,
+        country: Optional[str] = None,
+        auto_close: Optional[bool] = None,
+        timeout: Optional[int] = None,
+        debug: Optional[bool] = None,
+        extensions: Optional[List[str]] = None,
+        block_images: Optional[bool] = None,
+        block_styles: Optional[bool] = None,
+        block_fonts: Optional[bool] = None,
+        block_media: Optional[bool] = None,
+        screenshot: Optional[bool] = None,
+        resolution: Optional[str] = None,
+        target_url: Optional[str] = None,
+        cache: Optional[bool] = None,
+        blacklist: Optional[bool] = None,
+        unblock: Optional[bool] = None,
+        unblock_timeout: Optional[int] = None,
+        browser_brand: Optional[str] = None,
+        byop_proxy: Optional[str] = None,
+    ):
+        if timeout is not None and timeout > 1800:
+            raise ValueError('timeout cannot exceed 1800 seconds (30 minutes)')
+
+        if proxy_pool is not None and isinstance(proxy_pool, str):
+            proxy_pool = ProxyPool(proxy_pool)
+
+        if os is not None and isinstance(os, str):
+            os = OperatingSystem(os)
+
+        self.proxy_pool = proxy_pool
+        self.os = os
+        self.session = session
+        self.country = country
+        self.auto_close = auto_close
+        self.timeout = timeout
+        self.debug = debug
+        self.extensions = extensions
+        self.block_images = block_images
+        self.block_styles = block_styles
+        self.block_fonts = block_fonts
+        self.block_media = block_media
+        self.screenshot = screenshot
+        self.resolution = resolution
+        self.target_url = target_url
+        self.cache = cache
+        self.blacklist = blacklist
+        self.unblock = unblock
+        self.unblock_timeout = unblock_timeout
+        self.browser_brand = browser_brand
+        # BYOP (Bring Your Own Proxy): full proxy URL
+        # Format: {protocol}://{user}:{pass}@{host}:{port}
+        # Supported protocols: http, https, socks5, socks5h, socks5+udp, socks5h+udp
+        # The +udp variants enable HTTP/3 (QUIC) via SOCKS5 UDP ASSOCIATE — only
+        # works with proxy providers that implement RFC 1928 UDP ASSOCIATE.
+        # Requires a Custom plan subscription. See:
+        # https://scrapfly.io/docs/cloud-browser-api/byop
+        self.byop_proxy = byop_proxy
+
+    def websocket_url(self, api_key: str, host: Optional[str] = None) -> str:
+        params = {'api_key': api_key}
+
+        if self.proxy_pool is not None:
+            params['proxy_pool'] = self.proxy_pool.value if isinstance(self.proxy_pool, ProxyPool) else self.proxy_pool
+
+        if self.os is not None:
+            params['os'] = self.os.value if isinstance(self.os, OperatingSystem) else self.os
+
+        if self.session is not None:
+            params['session'] = self.session
+
+        if self.country is not None:
+            params['country'] = self.country
+
+        if self.auto_close is not None:
+            params['auto_close'] = self._bool_to_http(self.auto_close)
+
+        if self.timeout is not None:
+            params['timeout'] = self.timeout
+
+        if self.debug is not None:
+            params['debug'] = self._bool_to_http(self.debug)
+
+        if self.extensions:
+            params['extensions'] = ','.join(self.extensions)
+
+        if self.block_images is not None:
+            params['block_images'] = self._bool_to_http(self.block_images)
+
+        if self.block_styles is not None:
+            params['block_styles'] = self._bool_to_http(self.block_styles)
+
+        if self.block_fonts is not None:
+            params['block_fonts'] = self._bool_to_http(self.block_fonts)
+
+        if self.block_media is not None:
+            params['block_media'] = self._bool_to_http(self.block_media)
+
+        if self.screenshot is not None:
+            params['screenshot'] = self._bool_to_http(self.screenshot)
+
+        if self.resolution is not None:
+            params['resolution'] = self.resolution
+
+        if self.target_url is not None:
+            params['target_url'] = self.target_url
+
+        if self.cache is not None:
+            params['cache'] = self._bool_to_http(self.cache)
+
+        if self.blacklist is not None:
+            params['blacklist'] = self._bool_to_http(self.blacklist)
+
+        if self.unblock is not None:
+            params['unblock'] = self._bool_to_http(self.unblock)
+
+        if self.unblock_timeout is not None:
+            params['unblock_timeout'] = self.unblock_timeout
+
+        if self.browser_brand is not None:
+            params['browser_brand'] = self.browser_brand
+
+        if self.byop_proxy is not None:
+            params['byop_proxy'] = self.byop_proxy
+
+        base_host = host or self.CLOUD_BROWSER_HOST
+        return base_host + '?' + urlencode(params)
+
+    def to_dict(self) -> Dict:
+        return {
+            'proxy_pool': self.proxy_pool.value if isinstance(self.proxy_pool, ProxyPool) else self.proxy_pool,
+            'os': self.os.value if isinstance(self.os, OperatingSystem) else self.os,
+            'session': self.session,
+            'country': self.country,
+            'auto_close': self.auto_close,
+            'timeout': self.timeout,
+            'debug': self.debug,
+            'extensions': self.extensions,
+            'block_images': self.block_images,
+            'block_styles': self.block_styles,
+            'block_fonts': self.block_fonts,
+            'block_media': self.block_media,
+            'screenshot': self.screenshot,
+            'resolution': self.resolution,
+            'target_url': self.target_url,
+            'cache': self.cache,
+            'blacklist': self.blacklist,
+            'unblock': self.unblock,
+            'unblock_timeout': self.unblock_timeout,
+            'browser_brand': self.browser_brand,
+            'byop_proxy': self.byop_proxy,
+        }
+
+    @staticmethod
+    def from_dict(browser_config_dict: Dict) -> 'BrowserConfig':
+        proxy_pool = browser_config_dict.get('proxy_pool', None)
+        if proxy_pool is not None:
+            proxy_pool = ProxyPool(proxy_pool)
+
+        os = browser_config_dict.get('os', None)
+        if os is not None:
+            os = OperatingSystem(os)
+
+        return BrowserConfig(
+            proxy_pool=proxy_pool,
+            os=os,
+            session=browser_config_dict.get('session', None),
+            country=browser_config_dict.get('country', None),
+            auto_close=browser_config_dict.get('auto_close', None),
+            timeout=browser_config_dict.get('timeout', None),
+            debug=browser_config_dict.get('debug', None),
+            extensions=browser_config_dict.get('extensions', None),
+            block_images=browser_config_dict.get('block_images', None),
+            block_styles=browser_config_dict.get('block_styles', None),
+            block_fonts=browser_config_dict.get('block_fonts', None),
+            block_media=browser_config_dict.get('block_media', None),
+            screenshot=browser_config_dict.get('screenshot', None),
+            resolution=browser_config_dict.get('resolution', None),
+            target_url=browser_config_dict.get('target_url', None),
+            cache=browser_config_dict.get('cache', None),
+            blacklist=browser_config_dict.get('blacklist', None),
+            unblock=browser_config_dict.get('unblock', None),
+            unblock_timeout=browser_config_dict.get('unblock_timeout', None),
+            browser_brand=browser_config_dict.get('browser_brand', None),
+            byop_proxy=browser_config_dict.get('byop_proxy', None),
+        )

--- a/scrapfly/client.py
+++ b/scrapfly/client.py
@@ -36,6 +36,7 @@ from .scrape_config import ScrapeConfig
 from .screenshot_config import ScreenshotConfig
 from .extraction_config import ExtractionConfig
 from .crawler import CrawlerConfig, CrawlerStartResponse, CrawlerStatusResponse, CrawlerArtifactResponse
+from .browser_config import BrowserConfig
 from . import __version__, ScrapeApiResponse, ScreenshotApiResponse, ExtractionApiResponse, HttpError, UpstreamHttpError
 
 logger = logging.getLogger(__name__)
@@ -81,6 +82,8 @@ MonitoringAggregation = Literal[
 class ScrapflyClient:
 
     HOST = 'https://api.scrapfly.io'
+    CLOUD_BROWSER_HOST = 'wss://browser.scrapfly.io'
+    CLOUD_BROWSER_API_HOST = 'https://browser.scrapfly.io'
     DEFAULT_CONNECT_TIMEOUT = 30
     DEFAULT_READ_TIMEOUT = 30
 
@@ -127,6 +130,7 @@ class ScrapflyClient:
         read_timeout:int = DEFAULT_READ_TIMEOUT,
         default_read_timeout:int = DEFAULT_READ_TIMEOUT,
         reporter:Optional[Callable]=None,
+        cloud_browser_host: Optional[str] = None,
         **kwargs
     ):
         if host[-1] == '/':  # remove last '/' if exists
@@ -150,6 +154,8 @@ class ScrapflyClient:
         self.host = host
         self.key = key
         self.verify = verify
+        self.cloud_browser_host = cloud_browser_host or self.CLOUD_BROWSER_HOST
+        self.cloud_browser_api_host = cloud_browser_host.replace('wss://', 'https://') if cloud_browser_host else self.CLOUD_BROWSER_API_HOST
         self.debug = debug
         self.connect_timeout = connect_timeout
         self.web_scraping_api_read_timeout = web_scraping_api_read_timeout
@@ -1119,3 +1125,279 @@ class ScrapflyClient:
             request=response.request,
             response=response
         )
+
+    def cloud_browser(self, browser_config: Optional[BrowserConfig] = None) -> str:
+        """
+        Get the WebSocket URL for a Cloud Browser session.
+        :param browser_config: Optional BrowserConfig - connection parameters
+        :return: str - the full wss:// URL for CDP connection
+        """
+        if browser_config is None:
+            browser_config = BrowserConfig()
+
+        return browser_config.websocket_url(api_key=self.key, host=self.cloud_browser_host)
+
+    def cloud_browser_unblock(
+        self,
+        url: str,
+        proxy_pool: Optional[str] = None,
+        country: Optional[str] = None,
+        os: Optional[str] = None,
+        timeout: Optional[int] = None,
+        browser_timeout: Optional[int] = None,
+        headers: Optional[Dict] = None,
+        body: Optional[str] = None,
+        method: Optional[str] = None,
+    ) -> Dict:
+        """
+        Bypass anti-bot protection and get a ready-to-use browser session.
+        :param url: Target URL to navigate to and bypass protection
+        :param proxy_pool: Proxy pool: 'datacenter' or 'residential'
+        :param country: ISO country code for proxy geolocation
+        :param os: Operating system fingerprint: 'linux', 'windows', 'macos'
+        :param timeout: Navigation timeout in seconds (max 300)
+        :param browser_timeout: Browser session timeout in seconds (max 1800)
+        :param headers: Custom request headers
+        :param body: Request body for POST/PUT/PATCH requests
+        :param method: HTTP method: GET, POST, PUT, PATCH, DELETE
+        :return: dict with ws_url, session_id, run_id
+        """
+        proxy_pool_map = {
+            'datacenter': 'public_datacenter_pool',
+            'residential': 'public_residential_pool',
+        }
+
+        json_body = {'url': url}
+
+        if proxy_pool is not None:
+            json_body['proxy_pool'] = proxy_pool_map.get(proxy_pool, proxy_pool)
+
+        if country is not None:
+            json_body['country'] = country
+
+        if os is not None:
+            json_body['os'] = os
+
+        if timeout is not None:
+            json_body['timeout'] = timeout
+
+        if browser_timeout is not None:
+            json_body['browser_timeout'] = browser_timeout
+
+        if headers is not None:
+            json_body['headers'] = headers
+
+        if body is not None:
+            json_body['body'] = body
+
+        if method is not None:
+            json_body['method'] = method
+
+        response = self._http_handler(
+            method='POST',
+            url=self.cloud_browser_api_host + '/unblock',
+            json=json_body,
+            params={'key': self.key},
+            verify=self.verify,
+            timeout=(self.connect_timeout, 155),
+            headers={
+                'content-type': 'application/json',
+                'user-agent': self.ua
+            },
+        )
+
+        response.raise_for_status()
+
+        return response.json()
+
+    def cloud_browser_session_stop(self, session_id: str) -> None:
+        """
+        Terminate a Cloud Browser session.
+        :param session_id: The session identifier to terminate
+        """
+        response = self._http_handler(
+            method='POST',
+            url=self.cloud_browser_api_host + '/session/' + session_id + '/stop',
+            params={'key': self.key},
+            verify=self.verify,
+            timeout=(self.connect_timeout, self.default_read_timeout),
+            headers={
+                'user-agent': self.ua
+            },
+        )
+
+        response.raise_for_status()
+
+    def cloud_browser_playback(self, run_id: str) -> Dict:
+        """
+        Get playback info for a debug session recording.
+        :param run_id: The unique run identifier
+        :return: dict with available, metadata, video_url
+        """
+        response = self._http_handler(
+            method='GET',
+            url=self.cloud_browser_api_host + '/run/' + run_id + '/playback',
+            params={'key': self.key},
+            verify=self.verify,
+            timeout=(self.connect_timeout, self.default_read_timeout),
+            headers={
+                'user-agent': self.ua
+            },
+        )
+
+        response.raise_for_status()
+
+        return response.json()
+
+    def cloud_browser_video(self, run_id: str, save_path: Optional[str] = None) -> bytes:
+        """
+        Download a debug session recording video.
+        :param run_id: The unique run identifier
+        :param save_path: Optional file path to save the video (e.g. 'recording.webm')
+        :return: bytes - raw video data
+        """
+        response = self._http_handler(
+            method='GET',
+            url=self.cloud_browser_api_host + '/run/' + run_id + '/video',
+            params={'key': self.key},
+            verify=self.verify,
+            timeout=(self.connect_timeout, 120),  # Videos can be large
+            headers={
+                'user-agent': self.ua
+            },
+            stream=True,
+        )
+
+        response.raise_for_status()
+
+        data = response.content
+        if save_path:
+            with open(save_path, 'wb') as f:
+                f.write(data)
+
+        return data
+
+    # --- Cloud Browser Extension Management ---
+
+    def cloud_browser_extension_list(self) -> Dict:
+        """
+        List all browser extensions for the current account.
+        :return: dict with 'extensions' list and 'quota' info (used, limit)
+        """
+        response = self._http_handler(
+            method='GET',
+            url=self.cloud_browser_api_host + '/extension',
+            params={'key': self.key},
+            verify=self.verify,
+            timeout=(self.connect_timeout, self.default_read_timeout),
+            headers={
+                'user-agent': self.ua
+            },
+        )
+
+        response.raise_for_status()
+        return response.json()
+
+    def cloud_browser_extension_get(self, extension_id: str) -> Dict:
+        """
+        Get details of a specific browser extension.
+        :param extension_id: The extension identifier
+        :return: dict with extension details
+        """
+        response = self._http_handler(
+            method='GET',
+            url=self.cloud_browser_api_host + '/extension/' + extension_id,
+            params={'key': self.key},
+            verify=self.verify,
+            timeout=(self.connect_timeout, self.default_read_timeout),
+            headers={
+                'user-agent': self.ua
+            },
+        )
+
+        response.raise_for_status()
+        return response.json()
+
+    def cloud_browser_extension_upload(self, file_path: str) -> Dict:
+        """
+        Upload a browser extension from a local file (.zip or .crx).
+        :param file_path: Path to the extension file
+        :return: dict with 'extension' details and 'is_update' flag
+        """
+        with open(file_path, 'rb') as f:
+            response = self._http_handler(
+                method='POST',
+                url=self.cloud_browser_api_host + '/extension',
+                params={'key': self.key},
+                files={'file': (os.path.basename(file_path), f)},
+                verify=self.verify,
+                timeout=(self.connect_timeout, self.default_read_timeout),
+                headers={
+                    'user-agent': self.ua
+                },
+            )
+
+        response.raise_for_status()
+        return response.json()
+
+    def cloud_browser_extension_upload_from_url(self, extension_url: str) -> Dict:
+        """
+        Install a browser extension from a URL pointing to a .crx file.
+        URL-based extensions auto-update on each browser session start.
+        :param extension_url: URL to the .crx extension file
+        :return: dict with 'extension' details and 'is_update' flag
+        """
+        response = self._http_handler(
+            method='POST',
+            url=self.cloud_browser_api_host + '/extension',
+            params={'key': self.key},
+            json={'extension_url': extension_url},
+            verify=self.verify,
+            timeout=(self.connect_timeout, self.default_read_timeout),
+            headers={
+                'content-type': 'application/json',
+                'user-agent': self.ua
+            },
+        )
+
+        response.raise_for_status()
+        return response.json()
+
+    def cloud_browser_extension_delete(self, extension_id: str) -> Dict:
+        """
+        Delete a browser extension.
+        :param extension_id: The extension identifier to delete
+        :return: dict with success status
+        """
+        response = self._http_handler(
+            method='DELETE',
+            url=self.cloud_browser_api_host + '/extension/' + extension_id,
+            params={'key': self.key},
+            verify=self.verify,
+            timeout=(self.connect_timeout, self.default_read_timeout),
+            headers={
+                'user-agent': self.ua
+            },
+        )
+
+        response.raise_for_status()
+        return response.json()
+
+    def cloud_browser_sessions(self) -> Dict:
+        """
+        List all running Cloud Browser sessions.
+        :return: dict with 'sessions' list and 'total' count
+        """
+        response = self._http_handler(
+            method='GET',
+            url=self.cloud_browser_api_host + '/sessions',
+            params={'key': self.key},
+            verify=self.verify,
+            timeout=(self.connect_timeout, self.default_read_timeout),
+            headers={
+                'user-agent': self.ua
+            },
+        )
+
+        response.raise_for_status()
+        return response.json()

--- a/scrapfly/scrape_config.py
+++ b/scrapfly/scrape_config.py
@@ -149,7 +149,8 @@ class ScrapeConfig(BaseApiConfig):
         os:Optional[str] = None,
         lang:Optional[List[str]] = None,
         auto_scroll:Optional[bool] = None,
-        cost_budget:Optional[int] = None
+        cost_budget:Optional[int] = None,
+        browser_brand:Optional[str] = None
     ):
         assert(type(url) is str)
 
@@ -202,6 +203,7 @@ class ScrapeConfig(BaseApiConfig):
         self.os = os
         self.auto_scroll = auto_scroll
         self.cost_budget = cost_budget
+        self.browser_brand = browser_brand
 
         if cookies:
             _cookies = []
@@ -381,6 +383,9 @@ class ScrapeConfig(BaseApiConfig):
         if self.os is not None:
             params['os'] = self.os
 
+        if self.browser_brand is not None:
+            params['browser_brand'] = self.browser_brand
+
         return params
 
     @staticmethod
@@ -478,6 +483,7 @@ class ScrapeConfig(BaseApiConfig):
             'os': self.os,
             'auto_scroll': self.auto_scroll,
             'cost_budget': self.cost_budget,
+            'browser_brand': self.browser_brand,
         }
 
     @staticmethod
@@ -532,6 +538,7 @@ class ScrapeConfig(BaseApiConfig):
         lang = scrape_config_dict.get('lang', None)
         auto_scroll = scrape_config_dict.get('auto_scroll', None)
         cost_budget = scrape_config_dict.get('cost_budget', None)
+        browser_brand = scrape_config_dict.get('browser_brand', None)
 
         return ScrapeConfig(
             url=url,
@@ -575,4 +582,5 @@ class ScrapeConfig(BaseApiConfig):
             lang=lang,
             auto_scroll=auto_scroll,
             cost_budget=cost_budget,
+            browser_brand=browser_brand,
         )

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,14 @@ EXTRA_DEPENDENCIES = {
     'webhook-server': [
         'flask',
     ],
-    'concurrency': []
+    'concurrency': [],
+    'browser': [
+        'playwright>=1.40.0',
+    ],
+    'browser-use': [
+        'playwright>=1.40.0',
+        'browser-use',
+    ]
 }
 
 all_deps = set()


### PR DESCRIPTION
## Summary

Add Cloud Browser support to the SDK.

- `BrowserConfig` exposes the full Cloud Browser parameter surface (`proxy_pool`, `os`, `country`, `session`, `auto_close`, `timeout`, `debug`, `extensions`, `block_images`, `block_styles`, `block_fonts`, `block_media`, `screenshot`, `resolution`, `target_url`, `cache`, `blacklist`, `unblock`, `unblock_timeout`, `browser_brand`, `byop_proxy`).
- `ScrapflyClient.cloud_browser(config)` builds the WebSocket URL ready for `playwright.connect_over_cdp()`.
- `byop_proxy` accepts `http`, `https`, `socks5`, `socks5h`, `socks5+udp`, `socks5h+udp`. The `+udp` variants enable HTTP/3 (QUIC) via SOCKS5 UDP ASSOCIATE for providers that implement RFC 1928 §7.

See https://scrapfly.io/docs/cloud-browser-api/getting-started

## Test plan

- [ ] `BrowserConfig().websocket_url(api_key)` returns a valid `wss://browser.scrapfly.io?...` URL
- [ ] `byop_proxy='socks5h+udp://...'` is properly URL-encoded as `byop_proxy=socks5h%2Budp%3A%2F%2F...`
- [ ] `to_dict` / `from_dict` round-trip preserves every field
- [ ] Connect via `playwright.connect_over_cdp(client.cloud_browser(config))` against the live Cloud Browser endpoint